### PR TITLE
chore: Compatibility with zig rules 0.4.0 and newer.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.11.0
       - run: zig build test
       - run: zig build apps
 
@@ -30,4 +32,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.11.0
       - run: zig fmt --check src/*.zig

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,14 +1,14 @@
-load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_library", "zig_package", "zig_test")
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_library", "zig_module", "zig_test")
 load("//tools/project:build_defs.bzl", "project")
 
 project(license = "gpl3-https")
 
-zig_package(
+zig_module(
     name = "sodium",
     main = "src/sodium.zig",
 )
 
-zig_package(
+zig_module(
     name = "tox",
     srcs = [
         "src/friend.zig",
@@ -23,13 +23,14 @@ zig_library(
     name = "zig-toxcore-c",
     cdeps = [
         "//c-toxcore",
+        "@libsodium",
         "@rules_zig//zig/lib:libc",
     ],
     main = "src/tox.zig",
     deps = [":tox"],
 )
 
-zig_package(
+zig_module(
     name = "node_info",
     srcs = [
         "apps/BootNode.zig",
@@ -46,6 +47,7 @@ zig_package(
     name = app,
     cdeps = [
         "//c-toxcore",
+        "@libsodium",
         "@rules_zig//zig/lib:libc",
     ],
     main = "apps/%s.zig" % app,

--- a/src/tox.zig
+++ b/src/tox.zig
@@ -19,12 +19,20 @@ const log = std.log.scoped(.tox);
 pub fn versionMajor() u32 {
     return c.tox_version_major();
 }
+test "major version should be 0" {
+    try std.testing.expectEqual(versionMajor(), 0);
+}
+
 /// The minor version number.
 /// Incremented when functionality is added without  breaking the API or ABI.
 /// Set to 0 when the major version number is incremented.
 pub fn versionMinor() u32 {
     return c.tox_version_minor();
 }
+test "minor version should not be 0" {
+    try std.testing.expect(versionMinor() != 0);
+}
+
 /// The patch or revision number.
 /// Incremented when bugfixes are applied without changing any functionality or
 /// API or ABI.
@@ -744,5 +752,5 @@ test {
 }
 
 test "String test" {
-    // try std.testing.expectEqualStrings("Hi", "Hi");
+    try std.testing.expectEqualStrings("Hi", "Hi");
 }


### PR DESCRIPTION
They renamed `zig_package` to `zig_module`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/zig-toxcore-c/8)
<!-- Reviewable:end -->
